### PR TITLE
Set locale to C before running `tr`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ tianocore_fd: _tianocore_prepare
 tianocore_img: _check_atf_tools _check_atf_slim _check_board_setting tianocore_fd
 	@echo "Build Tianocore $(BUILD_VARIANT_UFL) Image - ATF VERSION: $(ATF_MAJOR).$(ATF_MINOR).$(ATF_BUILD)..."
 	$(eval DBB_KEY := $(EDK2_PLATFORMS_SRC_DIR)/Platform/Ampere/$(BOARD_NAME_UFL)Pkg/TestKeys/Dbb_AmpereTest.priv.pem)
-	@dd bs=1024 count=2048 if=/dev/zero | tr "\000" "\377" > $(OUTPUT_RAW_IMAGE)
+	@dd bs=1024 count=2048 if=/dev/zero | LC_ALL=C tr "\000" "\377" > $(OUTPUT_RAW_IMAGE)
 	@dd bs=1 seek=0 conv=notrunc if=$(ATF_SLIM) of=$(OUTPUT_RAW_IMAGE)
 	@if [ $(MAJOR_VER)$(MINOR_VER) -gt 202 ]; then \
 		$(CERTTOOL) -n --ntfw-nvctr 0 --key-alg rsa --hash-alg sha384 --nt-fw-key $(DBB_KEY) --nt-fw-cert ${ATF_SLIM}.crt --nt-fw ${ATF_SLIM}; \
@@ -334,7 +334,7 @@ tianocore_img: _check_atf_tools _check_atf_slim _check_board_setting tianocore_f
 # For Ampere ATF version 1.03 and 2.01, the following supports adding 4MB padding to the final image for
 # compatibility with the support of firmware update utility.
 	@if [ $(ATF_MAJOR)$(ATF_MINOR) -eq 103 ] || [ $(ATF_MAJOR)$(ATF_MINOR) -eq 201 ]; then \
-		dd if=/dev/zero bs=1024 count=4096 | tr "\000" "\377" > $(OUTPUT_IMAGE); \
+		dd if=/dev/zero bs=1024 count=4096 | LC_ALL=C tr "\000" "\377" > $(OUTPUT_IMAGE); \
 		dd bs=1 seek=4194304 conv=notrunc if=$(OUTPUT_RAW_IMAGE) of=$(OUTPUT_IMAGE); \
 	else \
 		cp $(OUTPUT_RAW_IMAGE) $(OUTPUT_IMAGE); \
@@ -360,7 +360,7 @@ tianocore_capsule: tianocore_img dbukeys_auth
 			ln -sf $(realpath $(SCP_SLIM)) $(SCP_IMAGE); \
 		else \
 			echo "Append dummy data to origin SCP image"; \
-			dd bs=1 count=261632 if=/dev/zero | tr "\000" "\377" > $(SCP_IMAGE).append; \
+			dd bs=1 count=261632 if=/dev/zero | LC_ALL=C tr "\000" "\377" > $(SCP_IMAGE).append; \
 			dd bs=1 seek=0 conv=notrunc if=$(SCP_SLIM) of=$(SCP_IMAGE).append; \
 			openssl dgst -sha384 -sign $(DBU_KEY) -out $(SCP_IMAGE).sig $(SCP_IMAGE).append; \
 			cat $(SCP_IMAGE).sig $(SCP_IMAGE).append > $(SCP_IMAGE).signed; \
@@ -386,7 +386,7 @@ tianocore_capsule: tianocore_img dbukeys_auth
 	else \
 		echo "Sign Tianocore Image"; \
 		echo "Append to dummy byte to UEFI image"; \
-		dd bs=1 count=13630976 if=/dev/zero | tr "\000" "\377" > $(OUTPUT_RAW_IMAGE).append; \
+		dd bs=1 count=13630976 if=/dev/zero | LC_ALL=C tr "\000" "\377" > $(OUTPUT_RAW_IMAGE).append; \
 		dd bs=1 seek=0 conv=notrunc if=$(OUTPUT_RAW_IMAGE) of=$(OUTPUT_RAW_IMAGE).append; \
 		openssl dgst -sha384 -sign $(DBU_KEY) -out $(OUTPUT_RAW_IMAGE).sig $(OUTPUT_RAW_IMAGE).append; \
 		cat $(OUTPUT_RAW_IMAGE).sig $(OUTPUT_RAW_IMAGE).append > $(OUTPUT_RAW_IMAGE).signed; \

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ python nvparam.py -f Platform/Ampere/JadePkg/jade_board_setting.txt -o BUILDS/
 Generating the final image with the following commands:
 
 ```
-$ dd bs=1024 count=2048 if=/dev/zero | tr "\000" "\377" > BUILDS/jade_tianocore_atf/jade_tianocore_atf.img
+$ dd bs=1024 count=2048 if=/dev/zero | LC_ALL=C tr "\000" "\377" > BUILDS/jade_tianocore_atf/jade_tianocore_atf.img
 $ dd bs=1024 conv=notrunc if=<ampere_atf_image_filepath> of=BUILDS/jade_tianocore_atf/jade_tianocore_atf.img
 $ dd bs=1024 seek=1984 conv=notrunc if=BUILDS/jade_tianocore_atf/jade_board_setting.bin of=BUILDS/jade_tianocore_atf/jade_tianocore_atf.img
 $ dd bs=1024 seek=2048 if=BUILDS/jade_tianocore_atf/jade_tianocore.fip.signed of=BUILDS/jade_tianocore_atf/jade_tianocore_atf.img
@@ -113,7 +113,7 @@ Result:
 
 For Ampere ATF version 1.05 and earlier
 ```
-$ dd bs=1024 count=2048 if=/dev/zero | tr "\000" "\377" > BUILDS/jade_tianocore_atf/jade_tianocore_atf.cap.img
+$ dd bs=1024 count=2048 if=/dev/zero | LC_ALL=C tr "\000" "\377" > BUILDS/jade_tianocore_atf/jade_tianocore_atf.cap.img
 $ dd bs=1024 conv=notrunc if=<ampere_atf_image_filepath> of=BUILDS/jade_tianocore_atf/jade_tianocore_atf.cap.img
 $ dd bs=1024 seek=1984 conv=notrunc if=BUILDS/jade_tianocore_atf/jade_board_setting.bin of=BUILDS/jade_tianocore_atf/jade_tianocore_atf.cap.img
 $ dd bs=1024 seek=2048 if=BUILDS/jade_tianocore_atf/jade_tianocore.fip.signed of=BUILDS/jade_tianocore_atf/jade_tianocore_atf.cap.img

--- a/edk2-build.sh
+++ b/edk2-build.sh
@@ -136,12 +136,12 @@ function build_tianocore_atf
         TIANOCORE_ATF_SLIM="$DEST_DIR/${PLATFORM_LOWER}_tianocore_atf${LINUXBOOT_FMT}${BUILD_TYPE}_${VER}.${BUILD}.img"
         if [ ${ATF_VER} -eq 103 ] || [ ${ATF_VER} -eq 201 ]; then
             # 4Mb padding only in 1.03 ATF VERSION
-            dd bs=1024 count=6144 if=/dev/zero | tr "\000" "\377" > ${TIANOCORE_ATF_SLIM}
+            dd bs=1024 count=6144 if=/dev/zero | LC_ALL=C tr "\000" "\377" > ${TIANOCORE_ATF_SLIM}
             dd bs=1 seek=4194304 conv=notrunc if=${ATF_IMAGE} of=${TIANOCORE_ATF_SLIM}
             dd bs=1 seek=6225920 conv=notrunc if=$DEST_DIR/${PLATFORM_LOWER}_board_setting.bin of=${TIANOCORE_ATF_SLIM}
             dd bs=1024 seek=6144 if=$DEST_DIR/${PLATFORM_LOWER}_tianocore${LINUXBOOT_FMT}${BUILD_TYPE}_${VER}.${BUILD}.fip.signed of=${TIANOCORE_ATF_SLIM}
         else
-            dd bs=1024 count=2048 if=/dev/zero | tr "\000" "\377" > ${TIANOCORE_ATF_SLIM}
+            dd bs=1024 count=2048 if=/dev/zero | LC_ALL=C tr "\000" "\377" > ${TIANOCORE_ATF_SLIM}
             dd bs=1 conv=notrunc if=${ATF_IMAGE} of=${TIANOCORE_ATF_SLIM}
             if [ ${ATF_VER} -gt 107 ]; then
                 DBU_PRV_KEY="$PLATFORM_PATH/TestKeys/Dbu_AmpereTest.priv.pem"
@@ -160,7 +160,7 @@ function build_tianocore_atf
             if [ ${ATF_VER} -eq 103 ] || [ ${ATF_VER} -eq 201 ]; then
                 # Capsule not 4Mb padding
                 TIANOCORE_ATF_SLIM="$DEST_DIR/${PLATFORM_LOWER}_tianocore_atf${LINUXBOOT_FMT}${BUILD_TYPE}_${VER}.${BUILD}.cap.img"
-                dd bs=1024 count=2048 if=/dev/zero | tr "\000" "\377" > ${TIANOCORE_ATF_SLIM}
+                dd bs=1024 count=2048 if=/dev/zero | LC_ALL=C tr "\000" "\377" > ${TIANOCORE_ATF_SLIM}
                 dd bs=1 conv=notrunc if=${ATF_IMAGE} of=${TIANOCORE_ATF_SLIM}
                 dd bs=1 seek=2031616 conv=notrunc if=$DEST_DIR/${PLATFORM_LOWER}_board_setting.bin of=${TIANOCORE_ATF_SLIM}
                 dd bs=1024 seek=2048 if=$DEST_DIR/${PLATFORM_LOWER}_tianocore${LINUXBOOT_FMT}${BUILD_TYPE}_${VER}.${BUILD}.fip.signed of=${TIANOCORE_ATF_SLIM}
@@ -184,7 +184,7 @@ function build_tianocore_atf
                     exit 1
                 fi
                 echo "Append to dummy byte to UEFI image"
-                dd bs=1 count=13630976 if=/dev/zero | tr "\000" "\377" > ${TIANOCORE_ATF_SLIM}.append
+                dd bs=1 count=13630976 if=/dev/zero | LC_ALL=C tr "\000" "\377" > ${TIANOCORE_ATF_SLIM}.append
                 dd bs=1 seek=0 conv=notrunc if=${TIANOCORE_ATF_SLIM} of=${TIANOCORE_ATF_SLIM}.append
                 openssl dgst -sha384 -sign ${DBU_PRV_KEY} \
                     -out $DEST_DIR/${PLATFORM_LOWER}_tianocore_atf${BUILD_TYPE}_${VER}.${BUILD}.img.sig \
@@ -210,7 +210,7 @@ function build_tianocore_atf
                     fi
                     echo "Append dummy data to origin SCP image"
                     SCP_SLIM="$WS_BOARD/${PLATFORM_LOWER}_scp.slim"
-                    dd bs=1 count=261632 if=/dev/zero | tr "\000" "\377" > ${SCP_SLIM}.append
+                    dd bs=1 count=261632 if=/dev/zero | LC_ALL=C tr "\000" "\377" > ${SCP_SLIM}.append
                     dd bs=1 seek=0 conv=notrunc if=${SCP_IMAGE} of=${SCP_SLIM}.append
                     openssl dgst -sha384 -sign ${DBU_PRV_KEY} -out ${SCP_SLIM}.sig ${SCP_SLIM}.append
                     cat ${SCP_SLIM}.sig ${SCP_SLIM}.append > ${SCP_SLIM}.signed


### PR DESCRIPTION
The output of `tr` can be locale-dependent: for example on macOS the command `tr "\000" "\377"` generates c3 bf instead of ff unless LC_ALL=C is specified.

Avoid accidentally corrupting the SPI image by explicitly setting the locale to C before running `tr`.